### PR TITLE
Fix logging issue in Gspread integration

### DIFF
--- a/gspread_logging.py
+++ b/gspread_logging.py
@@ -55,6 +55,9 @@ def log_trade(action, instrument, price, stop_loss_price, take_profit_price, uni
             risk,  # Risk
         ]
 
+        # Debug log the trade data
+        logging.debug(f"Trade data being logged: {trade_data}")
+
         if worksheet:
             # Append the trade data to the worksheet
             worksheet.append_row(trade_data)


### PR DESCRIPTION
Add a debug log statement to capture trade data before logging it to the worksheet. This change aims to improve traceability and debugging of trade operations.