### PR TITLE
Update webhook to support optional stop loss and take profit prices

### DIFF
--- a/server.py
+++ b/server.py
@@ -281,11 +281,14 @@ async def webhook(token: str, request: Request):
 
     # Calculate units and trade details
     try:
+        stop_loss_price = post_data.get("stop_loss_price")  # Use .get() to handle missing keys
+        take_profit_price = post_data.get("take_profit_price")  # Use .get() to handle missing keys
+
         trade_details = await calculate_units(
             instrument=oanda_parameters["instrument"],
             price=oanda_parameters["price"],
-            stop_loss_price=post_data["stop_loss_price"],
-            take_profit_price=post_data["take_profit_price"],
+            stop_loss_price=float(stop_loss_price) if stop_loss_price else None,
+            take_profit_price=float(take_profit_price) if take_profit_price else None,
             risk_percent=1.0,
             trading_type=oanda_parameters["trading_type"],
         )


### PR DESCRIPTION
Enhance the webhook functionality to handle optional `stop_loss_price` and `take_profit_price` parameters in the `calculate_units` function. This change allows for more flexible trading strategies.