### PR TITLE
Remove JPY_USD from supported pairs

### DIFF
--- a/server.py
+++ b/server.py
@@ -68,7 +68,6 @@ SUPPORTED_PAIRS = [
     "EUR_USD",
     "GBP_USD",
     "USD_JPY",
-    "JPY_USD",
     "AUD_USD",
     "USD_CAD",
     "NZD_USD",


### PR DESCRIPTION
Eliminate JPY_USD from the list of supported currency pairs due to its absence in the instruments list.