### PR TITLE
Disable debug mode for Oanda demo account testing

### DIFF
--- a/oanda.py
+++ b/oanda.py
@@ -6,7 +6,7 @@ import aiofiles  # For asynchronous file I/O
 import httpx  # For asynchronous HTTP requests
 
 # Enable debug mode to log requests instead of sending them to OANDA
-DEBUG_MODE = True
+DEBUG_MODE = False
 
 def get_datetime_offset(offset_minutes: int = 15) -> str:
     """Get the current UTC time offset by a given number of minutes in RFC3339 format."""


### PR DESCRIPTION
Remove debug mode to streamline testing on the Oanda demo account.